### PR TITLE
⬆️ bump go to `v1.21`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         platform: [macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.21.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The goada library provides support for the WHATWG URL standard in Go.
 
 ## Requirements
 
-- Go 1.20 or better.
+- Go 1.21 or better.
 
 
 ### Examples

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/ada-url/goada
 
-go 1.20
+go 1.21


### PR DESCRIPTION
According to [Go Release Policy](https://go.dev/doc/devel/release) the old `v1.20` doesn't have support anymore, which means that Goada must be updated to at least Go `v.1.21`. 